### PR TITLE
Disable Wicket Source in delpoyment environment

### DIFF
--- a/wicket-source/src/main/java/net/ftlines/wicketsource/WicketSource.java
+++ b/wicket-source/src/main/java/net/ftlines/wicketsource/WicketSource.java
@@ -17,7 +17,7 @@ public class WicketSource {
 	 */
 	public static void configure(Application application)
 	{
-		if (usesDevelopmentConfig()) {
+		if (application.usesDevelopmentConfig()) {
 			application.getComponentInstantiationListeners().add(new AttributeModifyingInstantiationListener());
 			application.getComponentPostOnBeforeRenderListeners().add(new AttributeModifyingComponentVisitor());
 		}

--- a/wicket-source/src/main/java/net/ftlines/wicketsource/WicketSource.java
+++ b/wicket-source/src/main/java/net/ftlines/wicketsource/WicketSource.java
@@ -11,13 +11,16 @@ import org.apache.wicket.Application;
 public class WicketSource {
 
 	/**
-	 * Preferred entry point for configuring your WicketApplication automatically.
+	 * Preferred entry point for configuring your WicketApplication automatically. 
+	 * WicketSource configuration is only supposed to run in DEVELOPMENT configuration.
 	 * @param application Your wicket application
 	 */
 	public static void configure(Application application)
 	{
-		application.getComponentInstantiationListeners().add(new AttributeModifyingInstantiationListener());
-		application.getComponentPostOnBeforeRenderListeners().add(new AttributeModifyingComponentVisitor());
+		if (usesDevelopmentConfig()) {
+			application.getComponentInstantiationListeners().add(new AttributeModifyingInstantiationListener());
+			application.getComponentPostOnBeforeRenderListeners().add(new AttributeModifyingComponentVisitor());
+		}
 	}
 	
 }


### PR DESCRIPTION
The configuration of WicketSource shall only be run in DEVELOPMENT configuration, not in DEPLOYMENT configuration. Otherwise classnames and line numbers are exposed to users of the web application, which is a security leak.